### PR TITLE
Fix CV download link

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -31,7 +31,7 @@ export default function Header() {
         </button>
 
         <a
-          href="/cv-juanpablo.pdf"
+          href={`${import.meta.env.BASE_URL}cv-juanpablo.pdf`}
           download
           className="flex items-center gap-2 px-3 py-2 bg-gray-800 hover:bg-gray-700 text-white rounded-md text-sm font-medium transition shadow-lg"
         >


### PR DESCRIPTION
## Summary
- fix the link to download the CV so it works when a base path is used

## Testing
- `npm ci` *(fails: can't reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_685edab13a0c832eb85a90cd80e5dcdd