### PR TITLE
Add Jest setup and modal test

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+export default {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-react', { runtime: 'automatic' }]
+  ]
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+export default {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.[jt]sx?$': 'babel-jest'
+  },
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
+  },
+  testMatch: ['**/tests/**/*.test.jsx']
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "framer-motion": "^10.18.0",
@@ -20,6 +21,14 @@
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.4.1",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "jest": "^29.7.0",
+    "babel-jest": "^29.7.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.1.0",
+    "@testing-library/user-event": "^14.4.3",
+    "@babel/preset-env": "^7.24.0",
+    "@babel/preset-react": "^7.24.0",
+    "identity-obj-proxy": "^3.0.0"
   }
 }

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { FaGraduationCap, FaEgg, FaTimes } from "react-icons/fa";
+import FormacionComplementaria from "./FormacionComplementaria";
 
 export default function SkillsSection() {
   const [showEgg, setShowEgg] = useState(false);
+  const [showFormacion, setShowFormacion] = useState(false);
 
   return (
     <section className="relative bg-white py-20 px-6">
@@ -11,7 +13,10 @@ export default function SkillsSection() {
           <h2 className="text-3xl font-bold border-b-2 border-gray-300 inline-block">
             HABILIDADES TÉCNICAS
           </h2>
-          <button className="border border-gray-600 px-4 py-2 rounded-md flex items-center gap-2 hover:scale-105 transition">
+          <button
+            onClick={() => setShowFormacion(true)}
+            className="border border-gray-600 px-4 py-2 rounded-md flex items-center gap-2 hover:scale-105 transition"
+          >
             <FaGraduationCap />
             Formación Complementaria
           </button>
@@ -68,6 +73,15 @@ export default function SkillsSection() {
           </div>
         </div>
       </div>
+
+      {/* Formacion Complementaria Modal */}
+      {showFormacion && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-white text-gray-800 p-6 rounded-xl max-w-md shadow-lg relative">
+            <FormacionComplementaria onClose={() => setShowFormacion(false)} />
+          </div>
+        </div>
+      )}
 
       {/* Easter Egg Button */}
       <button

--- a/tests/Skills.test.jsx
+++ b/tests/Skills.test.jsx
@@ -1,0 +1,20 @@
+import '@testing-library/jest-dom';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SkillsSection from '../src/components/Skills.jsx';
+
+describe('SkillsSection modal', () => {
+  test('shows and hides FormacionComplementaria modal', async () => {
+    render(<SkillsSection />);
+    const openButton = screen.getByRole('button', { name: /formaci\u00f3n complementaria/i });
+    await userEvent.click(openButton);
+
+    const heading = await screen.findByRole('heading', { name: /formaci\u00f3n complementaria/i });
+    expect(heading).toBeInTheDocument();
+
+    const closeButton = within(heading.parentElement).getByRole('button');
+    await userEvent.click(closeButton);
+
+    expect(screen.queryByRole('heading', { name: /formaci\u00f3n complementaria/i })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add FormacionComplementaria modal logic in `Skills` component
- configure Jest and Babel for testing
- add test verifying the complementary training modal opens and closes
- expose `npm test` script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ede7b765c832eba02262cf6411181