### PR TITLE
Fix typos and add modal test

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Running tests
+
+This project uses Jest and React Testing Library. Run `npm test` to execute the test suite.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    ['@babel/preset-react', {runtime: 'automatic'}]
+  ]
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+export default {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['./jest.setup.js'],
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
+  },
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "framer-motion": "^10.18.0",
@@ -20,6 +21,12 @@
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.4.1",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.1.5",
+    "babel-jest": "^29.7.0",
+    "@babel/preset-env": "^7.24.0",
+    "@babel/preset-react": "^7.24.0"
   }
 }

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -86,7 +86,7 @@ export default function About() {
               <li><strong>Modal:</strong> Diploma en modal con fondo oscuro y botón de cierre</li>
               <li><strong>Animaciones:</strong> fadeIn en sección y modal (`fadeInScale`)</li>
               <li><strong>Iconos:</strong> `FaGraduationCap`, `FaTimes`, `FaEgg` desde `react-icons`</li>
-              <li><strong>Imágenes usadas:</strong> `profile.png`, `diploma-dam-camara.png`</li>
+              <li><strong>Imágenes usadas:</strong> `profile.png`, `diploma.png`</li>
             </ul>
           </div>
         </div>

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -118,7 +118,6 @@ export default function ExperienceSlider() {
               <li><strong>React:</strong> Componente funcional con estado `useState`</li>
               <li><strong>Tailwind CSS:</strong> Estilos utilitarios para estructura y diseño responsive</li>
               <li><strong>Swiper:</strong> Slider animado con navegación, paginación y loop</li>
-              <li><strong>Framer Motion:</strong> Transiciones y animaciones </li>
               <li><strong>Modularización:</strong> Proyectos destacados está separado en su propio componente</li>
               <li><strong>Easter Egg:</strong> Botón escondido que muestra info técnica como esta 😉</li>
             </ul>

--- a/src/components/FormacionComplementaria.jsx
+++ b/src/components/FormacionComplementaria.jsx
@@ -18,6 +18,7 @@ export default function FormacionComplementaria({ onClose }) {
         <button
           onClick={onClose}
           className="text-gray-500 hover:text-red-500 text-2xl transition"
+          aria-label="Cerrar modal"
         >
           <FaTimes />
         </button>

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { FaGraduationCap, FaEgg, FaTimes } from "react-icons/fa";
+import FormacionComplementaria from "./FormacionComplementaria";
 
 export default function SkillsSection() {
   const [showEgg, setShowEgg] = useState(false);
+  const [showFormacion, setShowFormacion] = useState(false);
 
   return (
     <section className="relative bg-white py-20 px-6">
@@ -11,7 +13,10 @@ export default function SkillsSection() {
           <h2 className="text-3xl font-bold border-b-2 border-gray-300 inline-block">
             HABILIDADES TÉCNICAS
           </h2>
-          <button className="border border-gray-600 px-4 py-2 rounded-md flex items-center gap-2 hover:scale-105 transition">
+          <button
+            onClick={() => setShowFormacion(true)}
+            className="border border-gray-600 px-4 py-2 rounded-md flex items-center gap-2 hover:scale-105 transition"
+          >
             <FaGraduationCap />
             Formación Complementaria
           </button>
@@ -68,6 +73,14 @@ export default function SkillsSection() {
           </div>
         </div>
       </div>
+
+      {showFormacion && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/10 backdrop-blur-sm">
+          <div className="bg-white max-w-3xl w-full rounded-xl shadow-2xl border border-gray-300 px-6 py-8 animate-fadeInScale">
+            <FormacionComplementaria onClose={() => setShowFormacion(false)} />
+          </div>
+        </div>
+      )}
 
       {/* Easter Egg Button */}
       <button

--- a/tests/Skills.test.jsx
+++ b/tests/Skills.test.jsx
@@ -1,0 +1,12 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import SkillsSection from '../src/components/Skills.jsx';
+
+it('toggles complementary training modal', () => {
+  render(<SkillsSection />);
+  const openButton = screen.getByRole('button', { name: /Formación Complementaria/i });
+  fireEvent.click(openButton);
+  expect(screen.getByRole('heading', { name: /Formación Complementaria/i })).toBeInTheDocument();
+  const closeButton = screen.getByLabelText(/cerrar modal/i);
+  fireEvent.click(closeButton);
+  expect(screen.queryByRole('heading', { name: /Formación Complementaria/i })).not.toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- correct asset name in `About` easter egg
- remove framer motion mention in `Experience` easter egg
- open complementary training modal from `Skills`
- expose close button with an accessible label
- configure Jest and add a test for the modal

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eda48d920832e878a46b0b31023ef