### PR TITLE
Fix button overlap on mobile

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -11,7 +11,7 @@ export default function Header() {
     <>
       {showContact && <ContactoFlotante onClose={() => setShowContact(false)} />}
 
-      <div className="absolute top-4 right-4 z-10 flex flex-col sm:flex-row gap-2 sm:gap-3 items-end sm:items-center">
+      <div className="absolute top-4 right-4 z-10 flex flex-row gap-2 sm:gap-3 items-center">
         <a
           href="https://www.linkedin.com/in/juan-pablo-palomares-ávila-07aaab205"
           target="_blank"


### PR DESCRIPTION
## Summary
- adjust header buttons layout so they no longer overlap the title on small screens

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eedc61690832ea3a6eb68d720ea66