### PR TITLE
Fix mobile modal close issue

### DIFF
--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -11,8 +11,16 @@ export default function Modal({ onClose, children }) {
     return () => window.removeEventListener('keydown', handleEsc);
   }, [onClose]);
 
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={handleOverlayClick}
+      role="dialog"
+    >
       <div className="relative bg-white text-gray-800 p-6 rounded-xl shadow-lg animate-fadeInScale max-w-md w-full">
         <button
           onClick={onClose}

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { FaGraduationCap, FaEgg, FaTimes } from "react-icons/fa";
 import FormacionComplementaria from "./FormacionComplementaria";
+import Modal from "./Modal";
 
 export default function SkillsSection() {
   const [showEgg, setShowEgg] = useState(false);
@@ -77,11 +78,9 @@ export default function SkillsSection() {
 
       {/* Formacion Complementaria Modal */}
       {showFormacion && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-white text-gray-800 p-6 rounded-xl max-w-md shadow-lg relative">
-            <FormacionComplementaria onClose={() => setShowFormacion(false)} />
-          </div>
-        </div>
+        <Modal onClose={() => setShowFormacion(false)}>
+          <FormacionComplementaria onClose={() => setShowFormacion(false)} />
+        </Modal>
       )}
 
       {/* Easter Egg Button */}

--- a/tests/Skills.test.jsx
+++ b/tests/Skills.test.jsx
@@ -17,4 +17,17 @@ describe('SkillsSection modal', () => {
 
     expect(screen.queryByRole('heading', { name: /formaci\u00f3n complementaria/i })).toBeNull();
   });
+
+  test('modal closes when clicking the overlay', async () => {
+    render(<SkillsSection />);
+    const openButton = screen.getByRole('button', { name: /formaci\u00f3n complementaria/i });
+    await userEvent.click(openButton);
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+
+    await userEvent.click(dialog);
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- allow closing Modal by clicking the dark backdrop
- use the reusable Modal component for 'Formacion Complementaria'
- add regression test for closing the modal by clicking the backdrop

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef11b6b8c832e98533b88c8f32689