### PR TITLE
Fix FlowTask link

### DIFF
--- a/flowtask.html
+++ b/flowtask.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FlowTask - Juan Pablo Palomares</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/flowtask.jsx"></script>
+  </body>
+</html>

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -40,7 +40,7 @@ export default function About() {
             </button>
             
             <a
-              href="/flowtask"
+              href={`${import.meta.env.BASE_URL}flowtask.html`}
               className="group relative overflow-hidden flex items-center justify-center gap-3 px-5 py-3 bg-gradient-to-r from-orange-500 via-red-500 to-orange-500 hover:from-orange-600 hover:via-red-600 hover:to-orange-600 text-white rounded-xl font-bold transition-all duration-300 shadow-xl hover:shadow-orange-500/30 hover:scale-105 border border-orange-400/20"
             >
               <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent -skew-x-12 -translate-x-full group-hover:translate-x-full transition-transform duration-700"></div>

--- a/src/flowtask.jsx
+++ b/src/flowtask.jsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import FlowTask from './components/FlowTask.tsx';
+
+createRoot(document.getElementById('root')).render(
+  <StrictMode>
+    <FlowTask />
+  </StrictMode>
+);


### PR DESCRIPTION
## Summary
- update About button to use BASE_URL
- add standalone FlowTask entrypoint and html page

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a7cdb30c0832e96c73632fd84e0dd