### PR TITLE
Fix icons in IA skills list

### DIFF
--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -11,6 +11,7 @@ import {
   FaGitAlt,
   FaProjectDiagram,
   FaRobot,
+  FaCogs,
   FaUserShield,
   FaTachometerAlt,
   FaCode,
@@ -38,7 +39,6 @@ import {
   SiNotion,
   SiOpenai,
 } from "react-icons/si";
-import { TbBrandGithubCopilot } from "react-icons/tb";
 import FormacionComplementaria from "./FormacionComplementaria";
 
 export default function SkillsSection() {
@@ -251,7 +251,7 @@ export default function SkillsSection() {
               </h3>
               <ul className="space-y-2 text-base">
                 <li className="flex items-center gap-3 p-2 rounded-xl bg-gray-800/50 hover:bg-gray-700/50 transition-colors">
-                  <TbBrandGithubCopilot className="text-xl" />
+                  <FaRobot className="text-xl" />
                   <span>GitHub Copilot</span>
                 </li>
                 <li className="flex items-center gap-3 p-2 rounded-xl bg-gray-800/50 hover:bg-gray-700/50 transition-colors">
@@ -259,7 +259,7 @@ export default function SkillsSection() {
                   <span>ChatGPT / Claude / Codex</span>
                 </li>
                 <li className="flex items-center gap-3 p-2 rounded-xl bg-gray-800/50 hover:bg-gray-700/50 transition-colors">
-                  <FaRobot className="text-xl" />
+                  <FaCogs className="text-xl" />
                   <span>Automatización con IA</span>
                 </li>
               </ul>


### PR DESCRIPTION
## Summary
- remove unused TbBrandGithubCopilot icon import
- use FaRobot, SiOpenai and FaCogs for AI & assistance skills

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a82a0a4ec832e8019387c294b01a7